### PR TITLE
index.ejsのメッセージ用textareaでheightを明示的に指定するようにした  #362

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -104,7 +104,7 @@
                 <tr>
                   <td style=""><input type="text" name="name" id="name" style="width:50px" placeholder="Name"/></td>
                   <td style="width: 100%; padding-right: 11px;">
-                    <textarea name="message" id="message" style="width: 100%; resize: vertical; line-height: 18px;" rows="1" autocomplete="off" placeholder="Message"/></textarea>
+                    <textarea name="message" id="message" style="width: 100%; resize: vertical; height: 20px;  line-height: 18px;" rows="1" autocomplete="off" placeholder="Message"/></textarea>
                   </td>
                   <td><button id="send_button" class="btn btn-small btn-primary"/>Send</button></td>
                   <td><input type="file" id="upload_chat" name="file" style="display:none"></input><button id="upload_chat_button" class="btn btn-small btn-inverse visible-phone" style="display:none"><i class="icon-upload icon-white"></i></button></td>


### PR DESCRIPTION
line-heightだけでなく、heightを明示的に指定するようにしました。


修正前

![20150412_devhub_orig](https://cloud.githubusercontent.com/assets/4059356/7106480/1956f9a6-e17d-11e4-9c6d-c0eeb8e17d97.png)

修正後

![20150413_devhub_new](https://cloud.githubusercontent.com/assets/4059356/7106481/2370f84c-e17d-11e4-9842-04a7ceed0ae1.png)
