### PR TITLE
/tmpと/DevHubが別パーティションorデバイスにマウントされている場合にファイルアップロードができない問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "moment": "2.12.0",
     "mongodb": "2.1.8",
     "multiparty": "^4.1.2",
+    "mv": "^2.1.1",
     "nightwatch": "0.8.18",
     "q": "^1.1.2",
     "request": "2.69.0",

--- a/routes/upload.js
+++ b/routes/upload.js
@@ -1,5 +1,6 @@
 var multiparty = require('multiparty');
 var fs = require('fs');
+var mv = require('mv');
 var util = require('../lib/util');
 
 module.exports.set_db = function(current_db){
@@ -32,7 +33,7 @@ exports.post = function(req, res) {
       var target_path = './static/uploads/' + file_name;
       var access_path = '/uploads/' + file_name;
 
-      fs.rename(tmp_path, target_path, function(err) {
+      mv(tmp_path, target_path, function(err) {
         if (err) {
           throw err;
         }


### PR DESCRIPTION
/tmpと/DevHub/static/uploadsが別パーティションorデバイスにマウントされている場合にファイルアップロードができない
これはfs.renameメソッドの仕様に起因する問題
回避のためにfs.renameを'mv'に置き換え
https://www.npmjs.com/package/mv