### PR TITLE
Support `--force-ssl` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ $ BASIC_AUTH_USER=user BASIC_AUTH_PASS=pass node app.js -p 3000 -d devhub_db -t 
 * BASIC_AUTH_USER ユーザ名
 * BASIC_AUTH_PASS パスワード
 
+### HTTPS 通信を強制する
+<pre>
+$ node app.js --force-ssl
+</pre>
+
+もしくは
+<pre>
+$ FORCE_SSL=true node app.js
+</pre>
+
 ## ビルド
 jsやcssを変更した場合はビルドが必要
 ### 開発向け

--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ program
   .option('-p, --port <n>', 'port no. default is 3000.')
   .option('-d, --db_name [name]', 'db name. default is "devhub_db".')
   .option('-t, --title_name [name]', 'title name. default is "".')
+  .option('--force-ssl', 'enforce access via https. default is false.')
   .option('BASIC_AUTH_USER', 'user name of basic authentication. define with env.')
   .option('BASIC_AUTH_PASS', 'password of basic authentication. define with env.')
   .option('GRIDFS', 'Set "true" when useing gridfs. define with env.')
@@ -29,6 +30,7 @@ try{
 app.set('port', program.port || process.env.PORT || 3000);
 app.set('db_name', program.db_name || 'devhub_db');
 app.set('title_name', program.title_name ? "for " + program.title_name : "");
+app.set('force_ssl', program.forceSsl || process.env.FORCE_SSL === 'true');
 app.set('basic_user', process.env.BASIC_AUTH_USER ? process.env.BASIC_AUTH_USER : "");
 app.set('basic_pass', process.env.BASIC_AUTH_PASS ? process.env.BASIC_AUTH_PASS : "");
 app.set('gridfs', process.env.GRIDFS == "true" ? true : false);
@@ -40,6 +42,16 @@ console.log(' title_name : ' + app.get('title_name'));
 console.log(' BASIC_AUTH_USER : ' + app.get('basic_user'));
 console.log(' BASIC_AUTH_PASS : ' + app.get('basic_pass'));
 console.log(' GRIDFS: ' + app.get('gridfs'));
+
+if (app.get('force_ssl')) {
+  app.get('*', function(req, res, next) {
+    if (req.recure || req.headers['x-forwarded-proto'] === 'https') {
+      next();
+    } else {
+      res.redirect('https://' + req.headers.host + req.url);
+    }
+  });
+}
 
 var client_info = require('./lib/client_info');
 client_info.options({
@@ -94,4 +106,4 @@ mongo_builder.ready(app.get('db_name'), function(db){
   console.log("listen!!!");
 });
 
-console.log('Server running at http://127.0.0.1:' + app.get('port') + '/');
+console.log('Server running at ' + (app.get('force_ssl') ? 'https' : 'http') + '://127.0.0.1:' + app.get('port') + '/');

--- a/app.json
+++ b/app.json
@@ -16,6 +16,10 @@
     },
     "GRIDFS": {
       "value": "true"
+    },
+    "FORCE_SSL": {
+      "required": false,
+      "value": "true"
     }
   }
 }


### PR DESCRIPTION
Heroku など http/https 両方をサポートしている環境の場合に、https での利用を強制できるようにしました。(互換性を意識して、デフォルトでは OFF にしました。)

 最近は SSL 導入の敷居が低くなってきているのと、セキュアな環境の地位が高まって来ているように感じます。
全世界に公開する環境でホスティングしているひとにとっては嬉しいかなと思ってつけてみました。