### PR TITLE
メモの編集画面にて、ショートカットキーでチェックボックスを反転する

### DIFF
--- a/static/javascripts/app/memo_view_model.js
+++ b/static/javascripts/app/memo_view_model.js
@@ -658,6 +658,18 @@ function MemoViewModel(param){
       }
 
       return false;
+    }else if (event.shiftKey && event.metaKey){ // shift + command : add or remove check
+      var $code = $('#share_memo_' + that.no).find('.code');
+      var current_row = $code.caretLine() - 1;
+      var edit_lines = that.edit_text().split('\n');
+
+      edit_lines[current_row] = $.decora.invert_checkbox(edit_lines[current_row]);
+
+      var elem = event.target;
+      var pos = elem.selectionStart;
+
+      that.edit_text(edit_lines.join('\n'));
+      elem.setSelectionRange(pos, pos);
     }else{
       that._adjustBlogUI();
       return true;

--- a/static/javascripts/libs/jquery.decora.js
+++ b/static/javascripts/libs/jquery.decora.js
@@ -659,6 +659,30 @@ var prettify = require('prettify');
     return tabled_text_array.join('\n');
   }
 
+  function _invert_checkbox(target_text){
+    return target_text.replace(REG_CHECKBOX, function(){
+      var matched_check = arguments[0];
+      var prefix = arguments[2];
+      if (prefix != undefined){
+        var sym_prefix = arguments[3];
+        var is_checked = arguments[4] == 'x';
+        if (is_checked){
+          return prefix + sym_prefix + SYM_UNCHECKED;
+        }else{
+          return prefix + sym_prefix + SYM_CHECKED;
+        }
+      }else{
+        var sym_prefix = arguments[6];
+        var is_checked = arguments[7] == 'x';
+        if (is_checked){
+          return sym_prefix + SYM_UNCHECKED;
+        }else{
+          return sym_prefix + SYM_CHECKED;
+        }
+      }
+    });
+  }
+
   $.decora = {
     to_html: function(target_text){
       return this.apply_to_deco_and_raw(
@@ -697,6 +721,10 @@ var prettify = require('prettify');
       }
 
       return bq_sepa_array.join('');
+    },
+
+    invert_checkbox: function(target_text){
+      return _invert_checkbox(target_text);
     }
   };
 })(jQuery);


### PR DESCRIPTION
メモ編集中にチェックボックス `- [ ]` をチェック状態にしたい場合がある。
手動で `x` を入力する以外に、同行にカーソルがある場合に特定キーで容易にチェック出来るようにしたい。

### 操作方法
- チェックボックスがある行にカーソルを当てて `command` + `shift` 