### PR TITLE
Revert "Bump lodash.mergewith from 4.6.1 to 4.6.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4528,20 +4528,10 @@
         "lodash.isarray": "^3.0.0"
       }
     },
-    "lodash.keysin": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-4.2.0.tgz",
-      "integrity": "sha1-jMP7NcLZSsxEOhhj4C+kB5nqbyg="
-    },
-    "lodash.mergewith": {
+    "lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
-    },
-    "lodash.rest": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.5.tgz",
-      "integrity": "sha1-lU73UEkmIDjJbR/Jiyj9r58Hcqo="
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.toarray": {
       "version": "4.4.0",


### PR DESCRIPTION
Reverts volpe28v/DevHub#592

heroku のビルドでエラーになるのでいったんリバート
```
-----> Installing dependencies
       Installing node modules
       npm ERR! lodash.merge not accessible from nightwatch
       
       npm ERR! A complete log of this run can be found in:
       npm ERR!     /tmp/npmcache.hOgIH/_logs/2021-01-18T08_06_47_603Z-debug.log
```
