### PR TITLE
node のバージョンが古くてビルドで落ちるのでアップグレード

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.11.3
+      - image: circleci/node:10.13.0
 
     working_directory: ~/repo
 


### PR DESCRIPTION
こんなエラーログ
```
7471 verbose stack Error: chromedriver@87.0.5 install: `node install.js`
7471 verbose stack Exit status 1
7471 verbose stack     at EventEmitter.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/npm-lifecycle/index.js:285:16)
7471 verbose stack     at emitTwo (events.js:126:13)
7471 verbose stack     at EventEmitter.emit (events.js:214:7)
7471 verbose stack     at ChildProcess.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/npm-lifecycle/lib/spawn.js:55:14)
7471 verbose stack     at emitTwo (events.js:126:13)
7471 verbose stack     at ChildProcess.emit (events.js:214:7)
7471 verbose stack     at maybeClose (internal/child_process.js:925:16)
7471 verbose stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:209:5)
7472 verbose pkgid chromedriver@87.0.5
7473 verbose cwd /home/circleci/repo
7474 verbose Linux 4.15.0-1077-aws
7475 verbose argv "/usr/local/bin/node" "/usr/local/bin/npm" "install"
7476 verbose node v8.11.3
7477 verbose npm  v5.6.0
7478 error code ELIFECYCLE
7479 error errno 1
7480 error chromedriver@87.0.5 install: `node install.js`
7480 error Exit status 1
7481 error Failed at the chromedriver@87.0.5 install script.
7481 error This is probably not a problem with npm. There is likely additional logging output above.
7482 verbose exit [ 1, true ]
```


ローカルでは 10系の node を使っていたのでエラーにはならなかったが、 CircleCI と同様に 8系で試したら再現した。
とりあえず package.json で指定しているバージョンと合わせて様子を見る
